### PR TITLE
Fix paths to binary files

### DIFF
--- a/commands.sh
+++ b/commands.sh
@@ -1,6 +1,6 @@
 sudo add-apt-repository universe
 sudo apt update
 sudo apt install -y alien libaio1
-cat oracle-instantclient-basic-21_part* > oracle-instantclient-basic-21.1.0.0.0-1.x86_64.rpm
-sudo alien -i oracle-instantclient-basic-21.1.0.0.0-1.x86_64.rpm
-rm oracle-instantclient-basic-21.1.0.0.0-1.x86_64.rpm
+cat $GITHUB_ACTION_PATH/oracle-instantclient-basic-21_part* > $GITHUB_ACTION_PATH/oracle-instantclient-basic-21.1.0.0.0-1.x86_64.rpm
+sudo alien -i $GITHUB_ACTION_PATH/oracle-instantclient-basic-21.1.0.0.0-1.x86_64.rpm
+rm $GITHUB_ACTION_PATH/oracle-instantclient-basic-21.1.0.0.0-1.x86_64.rpm


### PR DESCRIPTION
The current path definitions will look for the files in the repository checked out by "actions/checkout" since that is the current working directory.
The issue can be fixed by prefixing the paths with "$GITHUB_ACTION_PATH/" which will make sure that we look for the files inside the action.

(The tests did not fail because inside this repo the working directory is equal to the action directory and inside the "GoodManWENNumber2/oracle-11g-server-action" repo the tests dont fail beacuse of the checkout before using the action.)

Would love to hear your feedback and thanks for providing this action!